### PR TITLE
Update PluginDescription.java

### DIFF
--- a/src/main/java/net/tridentsdk/plugin/annotation/PluginDescription.java
+++ b/src/main/java/net/tridentsdk/plugin/annotation/PluginDescription.java
@@ -37,7 +37,7 @@ public @interface PluginDescription {
 
     String name();
 
-    double version() default 1.0;
+    String version() default "1.0";
 
     String description() default "Plugin made for TridentSDK";
 


### PR DESCRIPTION
Changes version() to return String instead of double
Reason: Allows for developers to put more information into the version, i.e. "1.0-BETA" etc.
