### PR TITLE
Create the base interfaces for Entities

### DIFF
--- a/src/main/java/net/tridentsdk/api/Location.java
+++ b/src/main/java/net/tridentsdk/api/Location.java
@@ -205,7 +205,7 @@ public class Location implements Serializable, Cloneable {
 
     public Location getRelative(Vector vector) {
         return new Location(this.getWorld(), vector.getX() + this.getX(), vector.getY() + this.getY(),
-                            vector.getZ() + this.getZ(), this.getYaw(), this.getPitch());
+                vector.getZ() + this.getZ(), this.getYaw(), this.getPitch());
     }
 
     /**

--- a/src/main/java/net/tridentsdk/api/Trident.java
+++ b/src/main/java/net/tridentsdk/api/Trident.java
@@ -39,7 +39,8 @@ public final class Trident {
     private static Server server;
     private static TridentLogger logger;
 
-    private Trident() {}
+    private Trident() {
+    }
 
     /**
      * Gets the server singleton that is currently running
@@ -65,7 +66,7 @@ public final class Trident {
         StackTraceElement element = elements[3];
 
         return "net.tridentsdk.server.TridentServer".equals(element.getClassName()) &&
-               "createServer".equals(element.getMethodName());
+                "createServer".equals(element.getMethodName());
     }
 
     /**

--- a/src/main/java/net/tridentsdk/api/docs/AccessNoDoc.java
+++ b/src/main/java/net/tridentsdk/api/docs/AccessNoDoc.java
@@ -27,7 +27,10 @@
 
 package net.tridentsdk.api.docs;
 
-import java.lang.annotation.*;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Target;
 
 /**
  * This annotation is for the use of documentation. This means that the access-level is not broad enough so that extra

--- a/src/main/java/net/tridentsdk/api/docs/InheritedOverride.java
+++ b/src/main/java/net/tridentsdk/api/docs/InheritedOverride.java
@@ -27,7 +27,9 @@
 
 package net.tridentsdk.api.docs;
 
-import java.lang.annotation.*;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
 
 /**
  * This annotation is for the use of documentation. This means that no protected and above methods are found in the

--- a/src/main/java/net/tridentsdk/api/entity/Ageable.java
+++ b/src/main/java/net/tridentsdk/api/entity/Ageable.java
@@ -1,36 +1,67 @@
+/*
+ * Copyright (c) 2014, The TridentSDK Team
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ *     3. Neither the name of TridentSDK nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 package net.tridentsdk.api.entity;
+
 /**
  * Represents a LivingEntity that has an age and has the ability to bread
- * 
- * @author TigerReborn
+ *
+ * @author TridentSDK Team
  */
 public interface Ageable extends LivingEntity {
-	/**
-	 * The current age of this entity, in ticks
-	 * 
-	 * @return the age of this entity
-	 */
-	int getAge();
-	
-	/**
-	 * Set the current age of this entity, in ticks
-	 * 
-	 * @param ticks the age to set
-	 */
-	void setAge(int ticks);
-	
-	/**
-	 * Whether or not this entity can breed or not, 
-	 * where the ability to breed represents whether or not this entity can become "in love"
-	 * 
-	 * @return whether or not this entity can be bred
-	 */
-    boolean canBreed();
-    
     /**
-     * Whether or not this entity is "in love", 
+     * The current age of this entity, in ticks
+     *
+     * @return the age of this entity
+     */
+    int getAge();
+
+    /**
+     * Set the current age of this entity, in ticks
+     *
+     * @param ticks the age to set
+     */
+    void setAge(int ticks);
+
+    /**
+     * Whether or not this entity can breed or not,
+     * where the ability to breed represents whether or not this entity can become "in love"
+     *
+     * @return whether or not this entity can be bred
+     */
+    boolean canBreed();
+
+    /**
+     * Whether or not this entity is "in love",
      * such that it will actively display the particle effect for breeding hearts and search for a mate
-     * 
+     *
      * @return whether or not this entity is in love
      */
     boolean isInLove();

--- a/src/main/java/net/tridentsdk/api/entity/ArmorStand.java
+++ b/src/main/java/net/tridentsdk/api/entity/ArmorStand.java
@@ -1,61 +1,91 @@
+/*
+ * Copyright (c) 2014, The TridentSDK Team
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ *     3. Neither the name of TridentSDK nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 package net.tridentsdk.api.entity;
 
 import net.tridentsdk.api.util.PartRotation;
 
 /**
  * Represents an Armor Stand
- * 
- * @author TigerReborn
+ *
+ * @author TridentSDK Team
  */
 public interface ArmorStand extends Equippable {
-    
+
     /**
      * Gets the slot properties of this Armor Stand
-     * 
+     *
      * @return this armor stand's slot properties
      */
     SlotProperties getSlotProperties();
-    
+
     /**
      * Whether or not this Armor Stand is invisible
-     * 
+     *
      * @return whether or not this Armor Stand is invisible
      */
     boolean isInvisible();
-    
+
     /**
      * Whether or not this Armor Stand should display its baseplate
-     * 
+     *
      * @return whether or not this Armor Stand should display its baseplate
      */
     boolean displayBaseplate();
-    
+
     /**
      * Whether or not this Armor Stand should display its arms
-     * 
+     *
      * @return whether or not this Armor Stand should display its arms
      */
     boolean displayArms();
-    
+
     /**
      * Whether or not this Armor Stand will fall or not
-     * 
+     *
      * @return whether or not this Armor Stand will fall or not
      */
     boolean useGravity();
-    
+
     /**
      * Returns the pose for this Armor Stand
-     * 
+     *
      * @return the post of this Armor Stand
      * @deprecated Uses magic numbers for indexing, exists until another way is pushed
      */
     @Deprecated
     PartRotation[] getPose();
-    
+
     /**
      * Whether or not this Armor Stand is small
-     * 
+     *
      * @return whether or not this Armor Stand is small
      */
     boolean isTiny();

--- a/src/main/java/net/tridentsdk/api/entity/Arrow.java
+++ b/src/main/java/net/tridentsdk/api/entity/Arrow.java
@@ -1,15 +1,45 @@
+/*
+ * Copyright (c) 2014, The TridentSDK Team
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ *     3. Neither the name of TridentSDK nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 package net.tridentsdk.api.entity;
 
 /**
  * Represents an Arrow
- * 
- * @author TigerReborn
+ *
+ * @author TridentSDK Team
  */
 public interface Arrow extends Projectile {
-    
+
     /**
      * Represents whether or not you can pickup this Arrow
-     * 
+     *
      * @return whether you can pickup this arrow or not
      */
     boolean canPickup();

--- a/src/main/java/net/tridentsdk/api/entity/Bat.java
+++ b/src/main/java/net/tridentsdk/api/entity/Bat.java
@@ -1,22 +1,52 @@
+/*
+ * Copyright (c) 2014, The TridentSDK Team
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ *     3. Neither the name of TridentSDK nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 package net.tridentsdk.api.entity;
 
 /**
  * Represents a Bat
- * 
- * @author TigerReborn
+ *
+ * @author TridentSDK Team
  */
 public interface Bat extends Neutral {
-    
+
     /**
      * Whether or not the bat is hanging
-     * 
+     *
      * @return whether or not the bat is hanging
      */
     boolean isHanging();
-    
+
     /**
      * Whether or not the bat is flying
-     * 
+     *
      * @return whether or not the bat is flying
      */
     boolean isFlying();

--- a/src/main/java/net/tridentsdk/api/entity/Boat.java
+++ b/src/main/java/net/tridentsdk/api/entity/Boat.java
@@ -1,8 +1,39 @@
+/*
+ * Copyright (c) 2014, The TridentSDK Team
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ *     3. Neither the name of TridentSDK nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 package net.tridentsdk.api.entity;
+
 /**
  * Represents a Boat
- * 
- * @author TigerReborn 
+ *
+ * @author TridentSDK Team
  */
 public interface Boat extends Vehicle {
 

--- a/src/main/java/net/tridentsdk/api/entity/Chicken.java
+++ b/src/main/java/net/tridentsdk/api/entity/Chicken.java
@@ -1,24 +1,54 @@
+/*
+ * Copyright (c) 2014, The TridentSDK Team
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ *     3. Neither the name of TridentSDK nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 package net.tridentsdk.api.entity;
 
 /**
  * Represents a Chicken
- * 
- * @author TigerReborn
+ *
+ * @author TridentSDK Team
  */
 public interface Chicken extends Ageable, Peaceful {
-	
-	/**
-	 * Whether or not this Chicken is a 'Chicken Jockey', 
-	 * defined by whether or not this Chicken will naturally despawn
-	 * 
-	 * @return whether or not this Chicken is a 'Chicken Jockey'
-	 */
-	boolean isChickenJockey();
-	
-	/**
-	 * Ticks until this Chicken will lay its egg
-	 * 
-	 * @return the number of ticks until this Chicken will lay an egg
-	 */
-	int getEggTicks();
+
+    /**
+     * Whether or not this Chicken is a 'Chicken Jockey',
+     * defined by whether or not this Chicken will naturally despawn
+     *
+     * @return whether or not this Chicken is a 'Chicken Jockey'
+     */
+    boolean isChickenJockey();
+
+    /**
+     * Ticks until this Chicken will lay its egg
+     *
+     * @return the number of ticks until this Chicken will lay an egg
+     */
+    int getEggTicks();
 }

--- a/src/main/java/net/tridentsdk/api/entity/CommandMinecart.java
+++ b/src/main/java/net/tridentsdk/api/entity/CommandMinecart.java
@@ -1,15 +1,45 @@
+/*
+ * Copyright (c) 2014, The TridentSDK Team
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ *     3. Neither the name of TridentSDK nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 package net.tridentsdk.api.entity;
 
 /**
  * Represents a Command Block Minecart
- * 
- * @author TigerReborn
+ *
+ * @author TridentSDK Team
  */
 public interface CommandMinecart extends MinecartBase {
-    
+
     /**
      * Gets the BlockState that represents this Minecart's command block
-     * 
+     *
      * @return the state of this Minecart's command block
      */
     Object getCommandBlockState();  /* TODO: Replace return type to valid implementation of BlockState */

--- a/src/main/java/net/tridentsdk/api/entity/Cow.java
+++ b/src/main/java/net/tridentsdk/api/entity/Cow.java
@@ -1,11 +1,41 @@
+/*
+ * Copyright (c) 2014, The TridentSDK Team
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ *     3. Neither the name of TridentSDK nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 package net.tridentsdk.api.entity;
 
 /**
  * Represents a Cow
- * 
- * @author TigerReborn
+ *
+ * @author TridentSDK Team
  */
-public interface Cow extends Ageable, Peaceful{
-	
-	
+public interface Cow extends Ageable, Peaceful {
+
+
 }

--- a/src/main/java/net/tridentsdk/api/entity/Creeper.java
+++ b/src/main/java/net/tridentsdk/api/entity/Creeper.java
@@ -1,36 +1,66 @@
+/*
+ * Copyright (c) 2014, The TridentSDK Team
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ *     3. Neither the name of TridentSDK nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 package net.tridentsdk.api.entity;
 
 /**
  * Represents a Creeper
- * 
- * @author TigerReborn
+ *
+ * @author TridentSDK Team
  */
-public interface Creeper extends Hostile{
-    
+public interface Creeper extends Hostile {
+
     /**
      * Whether or not this creeper is powered (Struck by lightning)
-     * 
+     *
      * @return whether or not this creeper is powered
      */
     boolean isPowered();
-    
+
     /**
      * Gets this creeper's explosion radius
-     * 
+     *
      * @return this creeper's explosion radius
      */
     float getExplosionRadius();
-    
+
     /**
      * Set whether or not this creeper is powered
-     * 
+     *
      * @param powered whether the creeper should be powered or not
      */
     void setPowered(boolean powered);
-    
+
     /**
      * Sets this creeper's explosion radius
-     * 
+     *
      * @param rad radius to change to
      */
     void setExplosionRadius(float rad);

--- a/src/main/java/net/tridentsdk/api/entity/Egg.java
+++ b/src/main/java/net/tridentsdk/api/entity/Egg.java
@@ -1,9 +1,39 @@
+/*
+ * Copyright (c) 2014, The TridentSDK Team
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ *     3. Neither the name of TridentSDK nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 package net.tridentsdk.api.entity;
 
 /**
  * Represents an Egg
- * 
- * @author TigerReborn
+ *
+ * @author TridentSDK Team
  */
 public interface Egg extends Projectile {
 

--- a/src/main/java/net/tridentsdk/api/entity/Enderman.java
+++ b/src/main/java/net/tridentsdk/api/entity/Enderman.java
@@ -1,22 +1,52 @@
+/*
+ * Copyright (c) 2014, The TridentSDK Team
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ *     3. Neither the name of TridentSDK nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 package net.tridentsdk.api.entity;
 
 /**
  * Represents an Enderman
- * 
- * @author TigerReborn
+ *
+ * @author TridentSDK Team
  */
-public interface Enderman extends Neutral{
-    
+public interface Enderman extends Neutral {
+
     /**
      * Get the block that this enderman is currently carrying
-     * 
+     *
      * @return the block that this entity is carrying
      */
     Object getBlockCarried();   /* TODO: Replace Object with valid implementation of BlockState */
-    
+
     /**
      * Gets the number of endermites spawned by this enderman. Affects spawn chance of other endermites
-     * 
+     *
      * @return the number of endermites spawned by this enderman
      */
     int getEndermiteCount();

--- a/src/main/java/net/tridentsdk/api/entity/Endermite.java
+++ b/src/main/java/net/tridentsdk/api/entity/Endermite.java
@@ -1,9 +1,39 @@
+/*
+ * Copyright (c) 2014, The TridentSDK Team
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ *     3. Neither the name of TridentSDK nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 package net.tridentsdk.api.entity;
 
 /**
  * Represents an Endermite.
- * 
- * @author TigerReborn
+ *
+ * @author TridentSDK Team
  */
 public interface Endermite extends Hostile {
 

--- a/src/main/java/net/tridentsdk/api/entity/Enderpearl.java
+++ b/src/main/java/net/tridentsdk/api/entity/Enderpearl.java
@@ -1,9 +1,39 @@
+/*
+ * Copyright (c) 2014, The TridentSDK Team
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ *     3. Neither the name of TridentSDK nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 package net.tridentsdk.api.entity;
 
 /**
  * Represents an Enderpearl
- * 
- * @author TigerReborn
+ *
+ * @author TridentSDK Team
  */
 public interface Enderpearl extends Projectile {
 

--- a/src/main/java/net/tridentsdk/api/entity/Entity.java
+++ b/src/main/java/net/tridentsdk/api/entity/Entity.java
@@ -27,11 +27,11 @@
 
 package net.tridentsdk.api.entity;
 
-import java.util.List;
-
 import net.tridentsdk.api.Location;
 import net.tridentsdk.api.util.Vector;
 import net.tridentsdk.api.world.World;
+
+import java.util.List;
 
 /**
  * Represents the abstraction for a mob, player, animal, or other "object" that is not a block type
@@ -148,10 +148,10 @@ public interface Entity {
      * @return the entity type that is represented
      */
     EntityType getType();
-    
+
     /**
      * Sets the properties of this entity to the specified properties
-     * 
+     *
      * @param properties the properties to set
      */
     void applyProperties(EntityProperties properties);

--- a/src/main/java/net/tridentsdk/api/entity/EntityProperties.java
+++ b/src/main/java/net/tridentsdk/api/entity/EntityProperties.java
@@ -1,9 +1,39 @@
+/*
+ * Copyright (c) 2014, The TridentSDK Team
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ *     3. Neither the name of TridentSDK nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 package net.tridentsdk.api.entity;
 
 /**
  * Represents the properties of an Entity not yet spawned in the world
- * 
- * @author TigerReborn
+ *
+ * @author TridentSDK Team
  */
 public interface EntityProperties {
 

--- a/src/main/java/net/tridentsdk/api/entity/Equippable.java
+++ b/src/main/java/net/tridentsdk/api/entity/Equippable.java
@@ -1,17 +1,47 @@
+/*
+ * Copyright (c) 2014, The TridentSDK Team
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ *     3. Neither the name of TridentSDK nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 package net.tridentsdk.api.entity;
 
 import net.tridentsdk.api.inventory.ItemStack;
 
 /**
  * Represents an entity that can be equipped
- * 
- * @author TigerReborn
+ *
+ * @author TridentSDK Team
  */
-public interface Equippable extends Entity{
-    
+public interface Equippable extends Entity {
+
     /**
      * This entity's equipment
-     * 
+     *
      * @return this entity's equipment
      */
     ItemStack[] getEquipment();

--- a/src/main/java/net/tridentsdk/api/entity/ExpBottle.java
+++ b/src/main/java/net/tridentsdk/api/entity/ExpBottle.java
@@ -1,10 +1,40 @@
+/*
+ * Copyright (c) 2014, The TridentSDK Team
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ *     3. Neither the name of TridentSDK nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 package net.tridentsdk.api.entity;
 
 /**
  * Represents an Exp Bottle
- * 
- * @author TigerReborn
+ *
+ * @author TridentSDK Team
  */
-public interface ExpBottle extends Projectile{
-    
+public interface ExpBottle extends Projectile {
+
 }

--- a/src/main/java/net/tridentsdk/api/entity/ExperienceOrb.java
+++ b/src/main/java/net/tridentsdk/api/entity/ExperienceOrb.java
@@ -1,38 +1,68 @@
+/*
+ * Copyright (c) 2014, The TridentSDK Team
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ *     3. Neither the name of TridentSDK nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 package net.tridentsdk.api.entity;
 
 /**
  * Represents an Experience Orb
- * 
- * @author TigerReborn
+ *
+ * @author TridentSDK Team
  */
-public interface ExperienceOrb extends Entity{
-    
+public interface ExperienceOrb extends Entity {
+
     /**
      * Sets the age of this Experience Orb entity
-     * 
+     *
      * @param age the age to set
      */
     void setAge(int age);
-    
+
     /**
      * Represents the age of this Experience Orb entity
-     * 
+     *
      * @return the age of this Experience Orb entity
      */
     int getAge();
-    
+
     /**
      * Represents the health of this Experience Orb entity.
-     * 
+     *
      * @return the health of this Experience Orb entity
      */
     short getHealth();
-    
+
     /**
      * Sets the health for this Experience Orb entity
-     * 
+     *
      * @param health the value to set the health to
      */
     void setHealth(short health);
-    
+
 }

--- a/src/main/java/net/tridentsdk/api/entity/FallingBlock.java
+++ b/src/main/java/net/tridentsdk/api/entity/FallingBlock.java
@@ -1,22 +1,52 @@
+/*
+ * Copyright (c) 2014, The TridentSDK Team
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ *     3. Neither the name of TridentSDK nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 package net.tridentsdk.api.entity;
 
 /**
  * Represents a dynamic tile
- * 
- * @author TigerReborn
+ *
+ * @author TridentSDK Team
  */
 public interface FallingBlock extends Entity {
-    
+
     /**
      * The state this FallingBlock represents
-     * 
+     *
      * @return the BlockState of this falling block
      */
     Object getState();  /* TODO: Change return type to valid implementation of BlockState */
-    
+
     /**
      * Whether or not this FallingBlock should drop when it breaks
-     * 
+     *
      * @return whether or not this FallingBlock should drop its item when it breaks
      */
     boolean shouldDrop();

--- a/src/main/java/net/tridentsdk/api/entity/Fireball.java
+++ b/src/main/java/net/tridentsdk/api/entity/Fireball.java
@@ -1,9 +1,39 @@
+/*
+ * Copyright (c) 2014, The TridentSDK Team
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ *     3. Neither the name of TridentSDK nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 package net.tridentsdk.api.entity;
 
 /**
  * Represents a Fireball
- * 
- * @author TigerReborn
+ *
+ * @author TridentSDK Team
  */
 public interface Fireball extends Projectile {
 

--- a/src/main/java/net/tridentsdk/api/entity/Firework.java
+++ b/src/main/java/net/tridentsdk/api/entity/Firework.java
@@ -1,19 +1,49 @@
+/*
+ * Copyright (c) 2014, The TridentSDK Team
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ *     3. Neither the name of TridentSDK nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 package net.tridentsdk.api.entity;
 
 import net.tridentsdk.api.inventory.FireworkProperties;
 
 public interface Firework extends Entity {
-    
+
     /**
      * Get the number of ticks that this Firework will explode at
-     * 
+     *
      * @return the number of ticks that this will explode at
      */
     int getLaunchTicks();
-    
+
     /**
      * Returns the properties of the Firework launched
-     * 
+     *
      * @return the properties of the firework launched
      */
     FireworkProperties getFirework();

--- a/src/main/java/net/tridentsdk/api/entity/FurnaceMinecart.java
+++ b/src/main/java/net/tridentsdk/api/entity/FurnaceMinecart.java
@@ -1,22 +1,52 @@
+/*
+ * Copyright (c) 2014, The TridentSDK Team
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ *     3. Neither the name of TridentSDK nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 package net.tridentsdk.api.entity;
 
 /**
  * Represents a Furnace Minecart
- * 
- * @author TigerReborn
+ *
+ * @author TridentSDK Team
  */
 public interface FurnaceMinecart extends Vehicle, InventoryHolder {
-    
+
     /**
      * The number of fuel ticks this Furnace Minecart has
-     * 
+     *
      * @return the number of fuel ticks
      */
     int getFuelTicks();
-    
+
     /**
      * Set the number of fuel ticks this Furnace Minecart has
-     * 
+     *
      * @param ticks the number of fuel ticks
      */
     void setFuelTicks(int ticks);

--- a/src/main/java/net/tridentsdk/api/entity/Ghast.java
+++ b/src/main/java/net/tridentsdk/api/entity/Ghast.java
@@ -1,15 +1,45 @@
+/*
+ * Copyright (c) 2014, The TridentSDK Team
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ *     3. Neither the name of TridentSDK nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 package net.tridentsdk.api.entity;
 
 /**
  * Represents a Ghast
- * 
- * @author TigerReborn
+ *
+ * @author TridentSDK Team
  */
 public interface Ghast extends Hostile {
-    
+
     /**
      * Gets the explosion radius used when a Fireball launched by this Ghast explodes
-     * 
+     *
      * @return this Ghast's fireball explosion radius
      */
     float getFireballRadius();

--- a/src/main/java/net/tridentsdk/api/entity/Guardian.java
+++ b/src/main/java/net/tridentsdk/api/entity/Guardian.java
@@ -1,15 +1,45 @@
+/*
+ * Copyright (c) 2014, The TridentSDK Team
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ *     3. Neither the name of TridentSDK nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 package net.tridentsdk.api.entity;
 
 /**
  * Represents a Guardian
- * 
- * @author TigerReborn 
+ *
+ * @author TridentSDK Team
  */
-public interface Guardian extends Hostile{
-    
+public interface Guardian extends Hostile {
+
     /**
      * Whether this Guardian is an Elder Guardian or not
-     * 
+     *
      * @return Whether or not this Guardian is an Elder Guardian
      */
     boolean isElder();

--- a/src/main/java/net/tridentsdk/api/entity/Hanging.java
+++ b/src/main/java/net/tridentsdk/api/entity/Hanging.java
@@ -1,17 +1,47 @@
+/*
+ * Copyright (c) 2014, The TridentSDK Team
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ *     3. Neither the name of TridentSDK nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 package net.tridentsdk.api.entity;
 
 import net.tridentsdk.api.Block;
 
 /**
  * Represents a hanging entity
- * 
- * @author TigerReborn
+ *
+ * @author TridentSDK Team
  */
 public interface Hanging extends Entity {
-    
+
     /**
      * The block this entity was placed on
-     * 
+     *
      * @return the Block this entity was placed on
      */
     Block getBlockPlacedOn();

--- a/src/main/java/net/tridentsdk/api/entity/HopperMinecart.java
+++ b/src/main/java/net/tridentsdk/api/entity/HopperMinecart.java
@@ -1,22 +1,52 @@
+/*
+ * Copyright (c) 2014, The TridentSDK Team
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ *     3. Neither the name of TridentSDK nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 package net.tridentsdk.api.entity;
 
 /**
  * Represents a Hopper Minecart
- * 
- * @author TigerReborn
+ *
+ * @author TridentSDK Team
  */
 public interface HopperMinecart extends MinecartBase, InventoryHolder {
-    
+
     /**
      * Gets the transfer cooldown of this Hopper Minecart
-     * 
+     *
      * @return
      */
     int getTransferCooldown();
-    
+
     /**
      * Sets the transfer cooldown of this Hopper Minecart
-     * 
+     *
      * @param cooldown
      */
     void setTransferCooldown(int cooldown);

--- a/src/main/java/net/tridentsdk/api/entity/Horse.java
+++ b/src/main/java/net/tridentsdk/api/entity/Horse.java
@@ -1,43 +1,73 @@
+/*
+ * Copyright (c) 2014, The TridentSDK Team
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ *     3. Neither the name of TridentSDK nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 package net.tridentsdk.api.entity;
 
 /**
  * Represents a Horse
- * 
- * @author TigerReborn
+ *
+ * @author TridentSDK Team
  */
 public interface Horse extends Tameable, Saddleable, InventoryHolder, Peaceful {
-	
-	/**
-	 * What breed of horse this is
-	 * 
-	 * @return the HorseType that represents this breed
-	 */
-	HorseType getBreed();
-	
-	/**
-	 * Whether or not this horse is grazing
-	 * 
-	 * @return if this horse is grazing or not
-	 */
+
+    /**
+     * What breed of horse this is
+     *
+     * @return the HorseType that represents this breed
+     */
+    HorseType getBreed();
+
+    /**
+     * Whether or not this horse is grazing
+     *
+     * @return if this horse is grazing or not
+     */
     boolean isGrazing();
-    
+
     /**
      * The temper of this horse, higher temper dictates that the horse is easier to tame
-     * 
+     *
      * @return the temper of this horse. Range of 0-100
      */
     int getTemper();
-    
+
     /**
      * Whether or not this horse has a chest
-     * 
+     *
      * @return false if this horse's breed is not a donkey or mule, or this horse has no chest
      */
     boolean hasChest();
-    
+
     /**
      * The variant of this horse, will return an invalid variant if this horse is not of a HORSE breed
-     * 
+     *
      * @return the variant of this horse
      */
     HorseVariant getVariant();

--- a/src/main/java/net/tridentsdk/api/entity/HorseType.java
+++ b/src/main/java/net/tridentsdk/api/entity/HorseType.java
@@ -1,44 +1,73 @@
+/*
+ * Copyright (c) 2014, The TridentSDK Team
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ *     3. Neither the name of TridentSDK nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 package net.tridentsdk.api.entity;
 
 public enum HorseType {
-	
-	/**
-	 * Generic Horse
-	 */
-	HORSE(0),
-	
-	/**
-	 * Donkey
-	 */
-	DONKEY(1),
-	
-	/**
-	 * Mule
-	 */
-	MULE(2),
-	
-	/**
-	 * Zombie horse
-	 */
-	ZOMBIE(3),
-	
-	/**
-	 * Skeleton horse
-	 */
-	SKELETON(4)
-	;
-	private int id;
-	
-	HorseType(int id){
-		this.id = id;
-	}
-	
-	private static HorseType[] byId = new HorseType[5];
-	
-	static{
-		for(HorseType type : HorseType.values()){
-			byId[type.id] = type;
-		}
-	}
+
+    /**
+     * Generic Horse
+     */
+    HORSE(0),
+
+    /**
+     * Donkey
+     */
+    DONKEY(1),
+
+    /**
+     * Mule
+     */
+    MULE(2),
+
+    /**
+     * Zombie horse
+     */
+    ZOMBIE(3),
+
+    /**
+     * Skeleton horse
+     */
+    SKELETON(4);
+    private int id;
+
+    HorseType(int id) {
+        this.id = id;
+    }
+
+    private static HorseType[] byId = new HorseType[5];
+
+    static {
+        for (HorseType type : HorseType.values()) {
+            byId[type.id] = type;
+        }
+    }
 
 }

--- a/src/main/java/net/tridentsdk/api/entity/HorseVariant.java
+++ b/src/main/java/net/tridentsdk/api/entity/HorseVariant.java
@@ -1,12 +1,42 @@
+/*
+ * Copyright (c) 2014, The TridentSDK Team
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ *     3. Neither the name of TridentSDK nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 package net.tridentsdk.api.entity;
 
 /**
  * Represents the variants of a Horse with a type of HORSE (id 0)
- * 
- * @author TigerReborn
+ *
+ * @author TridentSDK Team
  */
 public interface HorseVariant {
-	/*
+    /*
 	 * TODO: Implement Variants
 	 * general idea is that it may return 2 things:
 	 * 
@@ -14,5 +44,5 @@ public interface HorseVariant {
 	 * 
 	 * 2) Color
 	 */
-	
+
 }

--- a/src/main/java/net/tridentsdk/api/entity/Hostile.java
+++ b/src/main/java/net/tridentsdk/api/entity/Hostile.java
@@ -1,11 +1,41 @@
+/*
+ * Copyright (c) 2014, The TridentSDK Team
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ *     3. Neither the name of TridentSDK nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 package net.tridentsdk.api.entity;
 
 /**
  * Represents a hostile entity
  * Purpose of interface is to provide ease-of-access to large groups of a single type
  * (i.e. 'Hostiles', 'Friendlies')
- * 
- * @author TigerReborn
+ *
+ * @author TridentSDK Team
  */
 public interface Hostile extends LivingEntity {
 

--- a/src/main/java/net/tridentsdk/api/entity/InventoryHolder.java
+++ b/src/main/java/net/tridentsdk/api/entity/InventoryHolder.java
@@ -1,30 +1,61 @@
+/*
+ * Copyright (c) 2014, The TridentSDK Team
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ *     3. Neither the name of TridentSDK nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 package net.tridentsdk.api.entity;
 
-import net.tridentsdk.api.inventory.*;
+import net.tridentsdk.api.inventory.Inventory;
+import net.tridentsdk.api.inventory.ItemStack;
 
 /**
  * Represents an Entity that holds an Inventory
- * 
- * @author TigerReborn
+ *
+ * @author TridentSDK Team
  */
 public interface InventoryHolder extends Entity {
-	
+
 	/*
 	 * TODO: Convert the return types into a valid representation of their respective objects
 	 */
-	
-	/**
-	 * The Inventory that this entity holds
-	 * 
-	 * @return the Inventory that this entity holds
-	 */
-	Inventory getInventory();
-	
-	/**
-	 * The contents this slot
-	 * 
-	 *	@param slot the target slot
-	 * @return the contents of the specified slot
-	 */
-	ItemStack getContents(int slot);
+
+    /**
+     * The Inventory that this entity holds
+     *
+     * @return the Inventory that this entity holds
+     */
+    Inventory getInventory();
+
+    /**
+     * The contents this slot
+     *
+     * @param slot the target slot
+     * @return the contents of the specified slot
+     */
+    ItemStack getContents(int slot);
 }

--- a/src/main/java/net/tridentsdk/api/entity/Item.java
+++ b/src/main/java/net/tridentsdk/api/entity/Item.java
@@ -1,66 +1,96 @@
+/*
+ * Copyright (c) 2014, The TridentSDK Team
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ *     3. Neither the name of TridentSDK nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 package net.tridentsdk.api.entity;
 
 /**
  * Represents a dropped ItemStack
- * 
- * @author TigerReborn
+ *
+ * @author TridentSDK Team
  */
 public interface Item extends Entity {
-    
+
     /**
      * Sets the age of this Item entity
-     * 
+     *
      * @param age the age to set
      */
     void setAge(int age);
-    
+
     /**
      * Represents the age of this Item entity
-     * 
+     *
      * @return the age of this Item entity
      */
     int getAge();
-    
+
     /**
      * Represents the health of this Item entity.
-     * 
+     *
      * @return the health of this Item entity
      */
     short getHealth();
-    
+
     /**
      * Sets the health for this Item entity
-     * 
+     *
      * @param health the value to set the health to
      */
     void setHealth(short health);
-    
+
     /**
      * Represents the owner of this Item entity
-     * 
+     *
      * @return
      */
     String getOwner();
-    
+
     /**
      * Sets the owner of this Item entity. Nobody else can pickup this Item until 10 seconds
      * are left in its life if this value is set
-     * 
+     *
      * @param owner The name of the Player to set this too
      */
     void setOwner(String owner);
-    
+
     /**
      * Gets the name of the Player that dropped this
      * Will return {@code null} if this was spawned unnaturally
-     * 
+     *
      * @return the name of the Player that dropped this
      */
     String getDropper();
-    
+
     /**
      * Sets the Player who dropped this Item
-     * 
+     *
      * @param dropper the name of the Player who will become the dropper
      */
     void setDropper(String dropper);

--- a/src/main/java/net/tridentsdk/api/entity/ItemFrame.java
+++ b/src/main/java/net/tridentsdk/api/entity/ItemFrame.java
@@ -1,25 +1,55 @@
+/*
+ * Copyright (c) 2014, The TridentSDK Team
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ *     3. Neither the name of TridentSDK nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 package net.tridentsdk.api.entity;
 
 import net.tridentsdk.api.inventory.ItemStack;
 
 /**
  * Represents an ItemFrame
- * 
- * @author TigerReborn
+ *
+ * @author TridentSDK Team
  */
-public interface ItemFrame extends Hanging{
-    
+public interface ItemFrame extends Hanging {
+
     /**
      * Get the current ItemStack this ItemFrame has
-     * 
+     *
      * @return the current ItemStack this ItemFrame has
      */
     ItemStack getCurrentItem();
-    
+
     /**
      * Get the rotation of this ItemFrame's ItemStack
      * This is the number of times this has been rotated 45 degrees
-     * 
+     *
      * @return the rotation of this ItemFrame's ItemStack
      */
     byte getItemStackRotation();

--- a/src/main/java/net/tridentsdk/api/entity/LivingEntity.java
+++ b/src/main/java/net/tridentsdk/api/entity/LivingEntity.java
@@ -1,3 +1,33 @@
+/*
+ * Copyright (c) 2014, The TridentSDK Team
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ *     3. Neither the name of TridentSDK nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 package net.tridentsdk.api.entity;
 
 import net.tridentsdk.api.Location;

--- a/src/main/java/net/tridentsdk/api/entity/MagmaCube.java
+++ b/src/main/java/net/tridentsdk/api/entity/MagmaCube.java
@@ -1,9 +1,39 @@
+/*
+ * Copyright (c) 2014, The TridentSDK Team
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ *     3. Neither the name of TridentSDK nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 package net.tridentsdk.api.entity;
 
 /**
  * Represents a Magma Cube
- * 
- * @author TigerReborn
+ *
+ * @author TridentSDK Team
  */
 public interface MagmaCube extends Slime {
 

--- a/src/main/java/net/tridentsdk/api/entity/MinecartBase.java
+++ b/src/main/java/net/tridentsdk/api/entity/MinecartBase.java
@@ -1,50 +1,80 @@
+/*
+ * Copyright (c) 2014, The TridentSDK Team
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ *     3. Neither the name of TridentSDK nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 package net.tridentsdk.api.entity;
 
 /**
  * Represents the generic Minecart
- * 
- * @author TigerReborn
+ *
+ * @author TridentSDK Team
  */
 public interface MinecartBase extends Vehicle {
-    
+
     /**
      * Represents this Minecart's display tile, in the form of a BlockState
-     * 
+     *
      * @return the display tile of this Minecart
      */
     Object getDisplayTile();    /* TODO: Change return type to valid implementation of BlockState */
-    
+
     /**
      * Set this Minecart's display tile to the specified block state
-     * 
+     *
      * @param blockState the state to set this to
      */
     void setDisplayTile(Object blockState);    /* TODO: Change param type to valid implementation of BlockState */
-    
+
     /**
      * Get the offset for this Minecart's display tile
-     * 
+     *
      * @return the offset for this Minecart's display tile
      */
     int getDisplayTileOffset();
-    
+
     /**
      * Set the offset for this Minecart's display tile
-     * 
+     *
      * @param offset the offset to set
      */
     void setDisplayTileOffset(int offset);
-    
+
     /**
      * Gets the custom name of this Minecart
-     * 
+     *
      * @return the custom name of this Minecart
      */
     String getName();
-    
+
     /**
      * Sets the custom name of this Minecart
-     * 
+     *
      * @param name the new value of the custom name
      */
     void setName(String name);

--- a/src/main/java/net/tridentsdk/api/entity/Mooshroom.java
+++ b/src/main/java/net/tridentsdk/api/entity/Mooshroom.java
@@ -1,9 +1,39 @@
+/*
+ * Copyright (c) 2014, The TridentSDK Team
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ *     3. Neither the name of TridentSDK nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 package net.tridentsdk.api.entity;
 
 /**
  * Represents a Mooshroom Cow
- * 
- * @author TigerReborn
+ *
+ * @author TridentSDK Team
  */
 public interface Mooshroom extends Cow {
 

--- a/src/main/java/net/tridentsdk/api/entity/Neutral.java
+++ b/src/main/java/net/tridentsdk/api/entity/Neutral.java
@@ -1,18 +1,48 @@
+/*
+ * Copyright (c) 2014, The TridentSDK Team
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ *     3. Neither the name of TridentSDK nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 package net.tridentsdk.api.entity;
 
 /**
  * Represents a neutral entity
  * Purpose of interface is to provide ease-of-access to large groups of a single type
  * (i.e. 'Hostiles', 'Friendlies')
- * 
- * @author TigerReborn
+ *
+ * @author TridentSDK Team
  */
-public interface Neutral extends LivingEntity{
-    
+public interface Neutral extends LivingEntity {
+
     /**
      * Whether or not this entity has been angered. Note, not all neutral entities can be angered.
      * When an entity is angered, it is considered hostile
-     * 
+     * <p/>
      * return Whether this entity is angered or not
      */
     boolean isHostile();

--- a/src/main/java/net/tridentsdk/api/entity/Ocelot.java
+++ b/src/main/java/net/tridentsdk/api/entity/Ocelot.java
@@ -1,17 +1,47 @@
+/*
+ * Copyright (c) 2014, The TridentSDK Team
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ *     3. Neither the name of TridentSDK nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 package net.tridentsdk.api.entity;
 
 /**
  * Represents an Ocelot
- * 
- * @author TigerReborn
+ *
+ * @author TridentSDK Team
  */
 public interface Ocelot extends Tameable, Peaceful {
-	
-	/**
-	 * The breed of this ocelot, represented as a {@link net.tridentsdk.api.entity.OcelotType}OcelotType
-	 * 
-	 * @return the breed of this ocelot
-	 */
-	OcelotType getBreed();
+
+    /**
+     * The breed of this ocelot, represented as a {@link net.tridentsdk.api.entity.OcelotType}OcelotType
+     *
+     * @return the breed of this ocelot
+     */
+    OcelotType getBreed();
 
 }

--- a/src/main/java/net/tridentsdk/api/entity/OcelotType.java
+++ b/src/main/java/net/tridentsdk/api/entity/OcelotType.java
@@ -1,45 +1,74 @@
+/*
+ * Copyright (c) 2014, The TridentSDK Team
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ *     3. Neither the name of TridentSDK nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 package net.tridentsdk.api.entity;
 
 /**
  * Represents the type of an Ocelot
- * 
- * @author TigerReborn
+ *
+ * @author TridentSDK Team
  */
 public enum OcelotType {
-	
-	/**
-	 * Wild
-	 */
-	WILD(0),
-	
-	/**
-	 * Tuxedo
-	 */
-	TUXEDO(1),
-	
-	/**
-	 * Tabby
-	 */
-	TABBY(2),
-	
-	/**
-	 * Siamese
-	 */
-	SIAMESE(3)
-	;
-	
-	private int id;
-	
-	OcelotType(int id){
-		this.id = id;
-	}
-	
-	private static OcelotType[] byId = new OcelotType[4];
-	
-	static{
-		for(OcelotType type : OcelotType.values()){
-			byId[type.id] = type;
-		}
-	}
+
+    /**
+     * Wild
+     */
+    WILD(0),
+
+    /**
+     * Tuxedo
+     */
+    TUXEDO(1),
+
+    /**
+     * Tabby
+     */
+    TABBY(2),
+
+    /**
+     * Siamese
+     */
+    SIAMESE(3);
+
+    private int id;
+
+    OcelotType(int id) {
+        this.id = id;
+    }
+
+    private static OcelotType[] byId = new OcelotType[4];
+
+    static {
+        for (OcelotType type : OcelotType.values()) {
+            byId[type.id] = type;
+        }
+    }
 
 }

--- a/src/main/java/net/tridentsdk/api/entity/Painting.java
+++ b/src/main/java/net/tridentsdk/api/entity/Painting.java
@@ -1,15 +1,45 @@
+/*
+ * Copyright (c) 2014, The TridentSDK Team
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ *     3. Neither the name of TridentSDK nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 package net.tridentsdk.api.entity;
 
 /**
  * Represents a Painting
- * 
- * @author TigerReborn
+ *
+ * @author TridentSDK Team
  */
-public interface Painting extends Hanging{
-    
+public interface Painting extends Hanging {
+
     /**
      * Get the motive of this Painting
-     * 
+     *
      * @return the name of this Painting's motive
      */
     String getMotive();

--- a/src/main/java/net/tridentsdk/api/entity/Peaceful.java
+++ b/src/main/java/net/tridentsdk/api/entity/Peaceful.java
@@ -1,12 +1,42 @@
+/*
+ * Copyright (c) 2014, The TridentSDK Team
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ *     3. Neither the name of TridentSDK nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 package net.tridentsdk.api.entity;
 
 /**
  * Represents a paceful entity
  * Purpose of interface is to provide ease-of-access to large groups of a single type
  * (i.e. 'Hostiles', 'Friendlies')
- * 
- * @author TigerReborn
+ *
+ * @author TridentSDK Team
  */
-public interface Peaceful extends LivingEntity{
+public interface Peaceful extends LivingEntity {
 
 }

--- a/src/main/java/net/tridentsdk/api/entity/Pig.java
+++ b/src/main/java/net/tridentsdk/api/entity/Pig.java
@@ -1,9 +1,39 @@
+/*
+ * Copyright (c) 2014, The TridentSDK Team
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ *     3. Neither the name of TridentSDK nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 package net.tridentsdk.api.entity;
 
 /**
  * Represents a Pig
- * 
- * @author TigerReborn
+ *
+ * @author TridentSDK Team
  */
 public interface Pig extends Ageable, Saddleable, Peaceful {
 

--- a/src/main/java/net/tridentsdk/api/entity/Player.java
+++ b/src/main/java/net/tridentsdk/api/entity/Player.java
@@ -1,8 +1,38 @@
+/*
+ * Copyright (c) 2014, The TridentSDK Team
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ *     3. Neither the name of TridentSDK nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 package net.tridentsdk.api.entity;
 
 /**
  * TODO
  */
-public interface Player extends LivingEntity{
-    
+public interface Player extends LivingEntity {
+
 }

--- a/src/main/java/net/tridentsdk/api/entity/Potion.java
+++ b/src/main/java/net/tridentsdk/api/entity/Potion.java
@@ -1,9 +1,39 @@
+/*
+ * Copyright (c) 2014, The TridentSDK Team
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ *     3. Neither the name of TridentSDK nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 package net.tridentsdk.api.entity;
 
 /**
  * Represents a Potion
- * 
- * @author TigerReborn
+ *
+ * @author TridentSDK Team
  */
 public interface Potion extends Projectile {
 

--- a/src/main/java/net/tridentsdk/api/entity/PrimeTNT.java
+++ b/src/main/java/net/tridentsdk/api/entity/PrimeTNT.java
@@ -1,22 +1,52 @@
+/*
+ * Copyright (c) 2014, The TridentSDK Team
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ *     3. Neither the name of TridentSDK nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 package net.tridentsdk.api.entity;
 
 /**
  * Represents a Primed TNT
- * 
- * @author TigerReborn
+ *
+ * @author TridentSDK Team
  */
 public interface PrimeTNT extends FallingBlock {
-    
+
     /**
      * The number of ticks until this Primed TNT explodes
-     * 
+     *
      * @return the number of ticks until this Primed TNT explodes
      */
     int getFuseTicks();
-    
+
     /**
      * Sets the number of fuse ticks
-     * 
+     *
      * @param ticks the number of ticks to set
      */
     void setFuseTicks(int ticks);

--- a/src/main/java/net/tridentsdk/api/entity/Projectile.java
+++ b/src/main/java/net/tridentsdk/api/entity/Projectile.java
@@ -1,24 +1,54 @@
+/*
+ * Copyright (c) 2014, The TridentSDK Team
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ *     3. Neither the name of TridentSDK nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 package net.tridentsdk.api.entity;
 
 import net.tridentsdk.api.Block;
 
 /**
  * Represents a Projectile
- * 
- * @author TigerReborn
+ *
+ * @author TridentSDK Team
  */
 public interface Projectile extends Entity {
-    
+
     /**
      * Represents the shooter of this Projectile, if applicable
-     * 
+     *
      * @return the shooter of this Projectile
      */
     Entity getProjectileSource();
-    
+
     /**
      * Represents the current tile (Block) that this Projectile is located in
-     * 
+     *
      * @return the current tile this Projectile is in
      */
     Block getCurrentTile();

--- a/src/main/java/net/tridentsdk/api/entity/Rabbit.java
+++ b/src/main/java/net/tridentsdk/api/entity/Rabbit.java
@@ -1,15 +1,45 @@
+/*
+ * Copyright (c) 2014, The TridentSDK Team
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ *     3. Neither the name of TridentSDK nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 package net.tridentsdk.api.entity;
 
 /**
  * Represents a Rabbit
- * 
- * @author TigerReborn
+ *
+ * @author TridentSDK Team
  */
-public interface Rabbit extends Neutral{
-    
+public interface Rabbit extends Neutral {
+
     /**
      * Get the breed of Rabbit that this Rabbit is
-     * 
+     *
      * @return the breed of Rabbit this rabbit is
      */
     RabbitType getBreed();

--- a/src/main/java/net/tridentsdk/api/entity/RabbitType.java
+++ b/src/main/java/net/tridentsdk/api/entity/RabbitType.java
@@ -1,32 +1,61 @@
+/*
+ * Copyright (c) 2014, The TridentSDK Team
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ *     3. Neither the name of TridentSDK nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 package net.tridentsdk.api.entity;
 
 public enum RabbitType {
-    
+
     BROWN(0),
-    
+
     WHITE(1),
-    
+
     BLACK(2),
-    
+
     WHITE_AND_BLACK(3),
-    
+
     GOLD(4),
-    
+
     SALT_AND_PEPPER(5),
-    
-    KILLER_RABBIT(99)
-    ;
-    
+
+    KILLER_RABBIT(99);
+
     private int id;
-    
-    RabbitType(int id){
+
+    RabbitType(int id) {
         this.id = id;
     }
-    
+
     private static RabbitType[] byId = new RabbitType[7];
-    
-    static{
-        for(RabbitType type : RabbitType.values()){
+
+    static {
+        for (RabbitType type : RabbitType.values()) {
             byId[type.id] = type;
         }
     }

--- a/src/main/java/net/tridentsdk/api/entity/Saddleable.java
+++ b/src/main/java/net/tridentsdk/api/entity/Saddleable.java
@@ -1,24 +1,54 @@
+/*
+ * Copyright (c) 2014, The TridentSDK Team
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ *     3. Neither the name of TridentSDK nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 package net.tridentsdk.api.entity;
 
 /**
  * Represents a living entity that can wear a saddle
- * 
- * @author TigerReborn
+ *
+ * @author TridentSDK Team
  */
 public interface Saddleable extends LivingEntity {
-	
-	/**
-	 * Whether this entity is saddled or not
-	 * 
-	 * @return whether or not this entity has a saddle
-	 */
-	boolean isSaddled();
-	
-	/**
-	 * Set whether or not this entity is saddled
-	 * 
-	 * @param saddled whether this entity should be saddled or not
-	 */
-	void setSaddled(boolean saddled);
-	
+
+    /**
+     * Whether this entity is saddled or not
+     *
+     * @return whether or not this entity has a saddle
+     */
+    boolean isSaddled();
+
+    /**
+     * Set whether or not this entity is saddled
+     *
+     * @param saddled whether this entity should be saddled or not
+     */
+    void setSaddled(boolean saddled);
+
 }

--- a/src/main/java/net/tridentsdk/api/entity/Sheep.java
+++ b/src/main/java/net/tridentsdk/api/entity/Sheep.java
@@ -1,24 +1,54 @@
+/*
+ * Copyright (c) 2014, The TridentSDK Team
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ *     3. Neither the name of TridentSDK nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 package net.tridentsdk.api.entity;
 
 /**
  * Represents a Sheep
- * 
- * @author TigerReborn
+ *
+ * @author TridentSDK Team
  */
 public interface Sheep extends Ageable, Peaceful {
-	
-	/**
-	 * The color of this sheep's wool
-	 * 
-	 * @return the color of this sheep's wool
-	 */
-	Object getColor();  /* TODO: Decide valid implementation of color for Sheep/Wool */
-	
-	/**
-	 * Whether or not this sheep can be sheared
-	 * 
-	 * @return whether or not this sheep can be sheared
-	 */
-	boolean isShearable();
+
+    /**
+     * The color of this sheep's wool
+     *
+     * @return the color of this sheep's wool
+     */
+    Object getColor();  /* TODO: Decide valid implementation of color for Sheep/Wool */
+
+    /**
+     * Whether or not this sheep can be sheared
+     *
+     * @return whether or not this sheep can be sheared
+     */
+    boolean isShearable();
 
 }

--- a/src/main/java/net/tridentsdk/api/entity/Skeleton.java
+++ b/src/main/java/net/tridentsdk/api/entity/Skeleton.java
@@ -1,10 +1,40 @@
+/*
+ * Copyright (c) 2014, The TridentSDK Team
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ *     3. Neither the name of TridentSDK nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 package net.tridentsdk.api.entity;
 
 public interface Skeleton extends Hostile, Equippable {
-    
+
     /**
      * Whether or not this is a Wither Skeleton
-     * 
+     *
      * @return whether or not this skeleton is a Wither Skeleton
      */
     boolean isWither();

--- a/src/main/java/net/tridentsdk/api/entity/Slime.java
+++ b/src/main/java/net/tridentsdk/api/entity/Slime.java
@@ -1,15 +1,45 @@
+/*
+ * Copyright (c) 2014, The TridentSDK Team
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ *     3. Neither the name of TridentSDK nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 package net.tridentsdk.api.entity;
 
 /**
  * Represents a Slime
- * 
- * @author TigerReborn
+ *
+ * @author TridentSDK Team
  */
 public interface Slime extends Hostile {
-    
+
     /**
      * Returns the size of this slime
-     * 
+     *
      * @return the size of this slime
      */
     int getSize();

--- a/src/main/java/net/tridentsdk/api/entity/SlotProperties.java
+++ b/src/main/java/net/tridentsdk/api/entity/SlotProperties.java
@@ -1,14 +1,44 @@
+/*
+ * Copyright (c) 2014, The TridentSDK Team
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ *     3. Neither the name of TridentSDK nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 package net.tridentsdk.api.entity;
 
 /**
  * Represents the slot properties of an Armor Stand
- * 
- * @author TigerReborn
+ *
+ * @author TridentSDK Team
  */
 public interface SlotProperties {
 
     /*
      * TODO: Toggle set/get of various Slots
      */
-    
+
 }

--- a/src/main/java/net/tridentsdk/api/entity/SmallFireball.java
+++ b/src/main/java/net/tridentsdk/api/entity/SmallFireball.java
@@ -1,9 +1,39 @@
+/*
+ * Copyright (c) 2014, The TridentSDK Team
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ *     3. Neither the name of TridentSDK nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 package net.tridentsdk.api.entity;
 
 /**
  * Represents a small Fireball
- * 
- * @author TigerReborn
+ *
+ * @author TridentSDK Team
  */
 public interface SmallFireball extends Fireball {
 

--- a/src/main/java/net/tridentsdk/api/entity/Snowball.java
+++ b/src/main/java/net/tridentsdk/api/entity/Snowball.java
@@ -1,9 +1,39 @@
+/*
+ * Copyright (c) 2014, The TridentSDK Team
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ *     3. Neither the name of TridentSDK nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 package net.tridentsdk.api.entity;
 
 /**
  * Represents a Snowball
- * 
- * @author TigerReborn
+ *
+ * @author TridentSDK Team
  */
 public interface Snowball extends Projectile {
 

--- a/src/main/java/net/tridentsdk/api/entity/SpawnerMinecart.java
+++ b/src/main/java/net/tridentsdk/api/entity/SpawnerMinecart.java
@@ -1,22 +1,52 @@
+/*
+ * Copyright (c) 2014, The TridentSDK Team
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ *     3. Neither the name of TridentSDK nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 package net.tridentsdk.api.entity;
 
 /**
  * Represents a Spawner Minecart
- * 
- * @author TigerReborn
+ *
+ * @author TridentSDK Team
  */
 public interface SpawnerMinecart extends MinecartBase {
-    
+
     /**
      * The spawn type of entities spawned by this Spawner Minecart
-     * 
+     *
      * @return the type of entity
      */
     EntityType getSpawnType();
-    
+
     /**
      * The properties that will be applied when an Entity is spawned by this
-     * 
+     *
      * @return the properties applied
      */
     EntityProperties getAppliedProperties();

--- a/src/main/java/net/tridentsdk/api/entity/TNTMinecart.java
+++ b/src/main/java/net/tridentsdk/api/entity/TNTMinecart.java
@@ -1,22 +1,52 @@
+/*
+ * Copyright (c) 2014, The TridentSDK Team
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ *     3. Neither the name of TridentSDK nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 package net.tridentsdk.api.entity;
 
 /**
  * Represents a TNT Minecart
- * 
- * @author TigerReborn
+ *
+ * @author TridentSDK Team
  */
-public interface TNTMinecart extends MinecartBase{
-    
+public interface TNTMinecart extends MinecartBase {
+
     /**
      * Gets the fuse time for this TNT Minecart
-     * 
+     *
      * @return this TNT Minecart's fuse time
      */
     int getFuseTime();
-    
+
     /**
      * Sets the fuse time for this TNT Minecart
-     * 
+     *
      * @param time the time to set
      */
     void setFuseTime(int time);

--- a/src/main/java/net/tridentsdk/api/entity/Tameable.java
+++ b/src/main/java/net/tridentsdk/api/entity/Tameable.java
@@ -1,33 +1,63 @@
+/*
+ * Copyright (c) 2014, The TridentSDK Team
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ *     3. Neither the name of TridentSDK nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 package net.tridentsdk.api.entity;
 
 import java.util.UUID;
 
 /**
  * Represents a tameable entity
- * 
- * @author TigerReborn
+ *
+ * @author TridentSDK Team
  */
-public interface Tameable extends Ageable{
-	
-	/**
-	 * Whether or not this entity is tamed
-	 * 
-	 * @return whether or not this entity is tamed
-	 */
-	boolean isTamed();
-	
-	/**
-	 * The UUID of this entity's owner
-	 * 
-	 * @return the UUID of the {@link net.tridentsdk.api.entity.Player}Player that owns this entity, {@code null} if untamed
-	 */
-	UUID getOwner();
-	
-	/**
-	 * Whether or not this entity is sitting
-	 * 
-	 * @return whether or not this entity is sitting
-	 */
-	boolean isSitting();
+public interface Tameable extends Ageable {
+
+    /**
+     * Whether or not this entity is tamed
+     *
+     * @return whether or not this entity is tamed
+     */
+    boolean isTamed();
+
+    /**
+     * The UUID of this entity's owner
+     *
+     * @return the UUID of the {@link net.tridentsdk.api.entity.Player}Player that owns this entity, {@code null} if untamed
+     */
+    UUID getOwner();
+
+    /**
+     * Whether or not this entity is sitting
+     *
+     * @return whether or not this entity is sitting
+     */
+    boolean isSitting();
 
 }

--- a/src/main/java/net/tridentsdk/api/entity/Tradeable.java
+++ b/src/main/java/net/tridentsdk/api/entity/Tradeable.java
@@ -1,21 +1,51 @@
-package net.tridentsdk.api.entity;
+/*
+ * Copyright (c) 2014, The TridentSDK Team
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ *     3. Neither the name of TridentSDK nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 
-import java.util.Collection;
+package net.tridentsdk.api.entity;
 
 import net.tridentsdk.api.trade.Trade;
 
+import java.util.Collection;
+
 /**
  * Represents an entity that can trade with the Player
- * 
- * @author TigerReborn
+ *
+ * @author TridentSDK Team
  */
 public interface Tradeable {
-	
-	/**
-	 * The trades this entity offers
-	 * 
-	 * @return the trades offered by this entity
-	 */
-	Collection<Trade> getTrades();
+
+    /**
+     * The trades this entity offers
+     *
+     * @return the trades offered by this entity
+     */
+    Collection<Trade> getTrades();
 
 }

--- a/src/main/java/net/tridentsdk/api/entity/Vehicle.java
+++ b/src/main/java/net/tridentsdk/api/entity/Vehicle.java
@@ -1,9 +1,39 @@
+/*
+ * Copyright (c) 2014, The TridentSDK Team
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ *     3. Neither the name of TridentSDK nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 package net.tridentsdk.api.entity;
 
 /**
  * Represents a Vehicle
- * 
- * @author TigerReborn
+ *
+ * @author TridentSDK Team
  */
 public interface Vehicle extends Entity {
 

--- a/src/main/java/net/tridentsdk/api/entity/Villager.java
+++ b/src/main/java/net/tridentsdk/api/entity/Villager.java
@@ -1,22 +1,52 @@
+/*
+ * Copyright (c) 2014, The TridentSDK Team
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ *     3. Neither the name of TridentSDK nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 package net.tridentsdk.api.entity;
 
 /**
  * Represents a Villager
- * 
- * @author TigerReborn
+ *
+ * @author TridentSDK Team
  */
 public interface Villager extends Ageable, Tradeable, Peaceful {
 
     /**
      * The profession of this villager
-     * 
+     *
      * @return the profession of this villager
      */
     VillagerProfession getProfession();
 
     /**
      * The career of this villager
-     * 
+     *
      * @return the career of this villager
      */
     VillagerCareer getCareer();
@@ -24,7 +54,7 @@ public interface Villager extends Ageable, Tradeable, Peaceful {
     /**
      * The current level of this villager's career. Affects trades offered by
      * this villager
-     * 
+     *
      * @return the current level of this villager's career
      */
     int getCareerLevel();
@@ -33,7 +63,7 @@ public interface Villager extends Ageable, Tradeable, Peaceful {
      * Sets the career of this villager. If the profession does not match the
      * specified career's parent profession, the profession will be set the
      * career's parent profession
-     * 
+     *
      * @param career the career you want to set for this villager
      */
     void setCareer(VillagerCareer career);
@@ -42,7 +72,7 @@ public interface Villager extends Ageable, Tradeable, Peaceful {
      * Sets the profession of this villager. If the current career does not have
      * the profession as its parent, the current career will be to the first
      * available career
-     * 
+     *
      * @param profession
      */
     void setProfession(VillagerProfession profession);

--- a/src/main/java/net/tridentsdk/api/entity/VillagerCareer.java
+++ b/src/main/java/net/tridentsdk/api/entity/VillagerCareer.java
@@ -1,92 +1,123 @@
+/*
+ * Copyright (c) 2014, The TridentSDK Team
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ *     3. Neither the name of TridentSDK nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 package net.tridentsdk.api.entity;
 
-import java.util.*;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 
-import com.google.common.collect.*;
+import java.util.Collection;
+import java.util.Map;
 
 public enum VillagerCareer {
-	/**
-	 * Fletcher
-	 */
-	FLETCHER(VillagerProfession.FARMER, 0),
-	
-	/**
-	 * Farmer
-	 */
-	FARMER(VillagerProfession.FARMER, 1),
-	
-	/**
-	 * Fisherman
-	 */
-	FISHERMAN(VillagerProfession.FARMER, 2),
-	
-	/**
-	 * Shepherd
-	 */
-	SHEPHERD(VillagerProfession.FARMER, 3),
-	
-	/**
-	 * Librarian
-	 */
-	LIBRARIAN(VillagerProfession.LIBRARAIAN, 0),
-	
-	/**
-	 * Cleric
-	 */
-	CLERIC(VillagerProfession.PRIEST, 0),
-	
-	/**
-	 * Tool smith
-	 */
-	TOOL_SMITH(VillagerProfession.BLACKSMITH, 0),
-	
-	/**
-	 * Armorer
-	 */
-	ARMORER(VillagerProfession.BLACKSMITH, 1),
-	
-	/**
-	 * Weapon smith
-	 */
-	WEAPON_SMITH(VillagerProfession.BLACKSMITH, 2),
-	
-	/**
-	 * Butcher
-	 */
-	BUTCHER(VillagerProfession.BUTCHER, 0),
-	
-	/**
-	 * Leatherworker
-	 */
-	LEATHERWORKER(VillagerProfession.BUTCHER, 1)
-	;
-	private VillagerProfession parent;
-	private int id;
-	
-	VillagerCareer(VillagerProfession parent, int id){
-		this.parent = parent;
-		this.id = id;
-	}
-	
-	private static Map<VillagerProfession, Collection<VillagerCareer>> byProfession = Maps.newHashMap();
-	
-	static{
-		Collection<VillagerCareer> parentColl = Lists.newArrayList();
-		VillagerProfession current = null;
-		for(VillagerCareer carrer : VillagerCareer.values()){
-			if(current == null){
-				current = carrer.parent;
-				parentColl.add(carrer);
-				continue;
-			}
-			if(current == carrer.parent){
-				parentColl.add(carrer);
-			} else {
-				byProfession.put(current, parentColl);
-				parentColl = Lists.newArrayList();
-				current = carrer.parent;
-			}
-		}
-	}
+    /**
+     * Fletcher
+     */
+    FLETCHER(VillagerProfession.FARMER, 0),
+
+    /**
+     * Farmer
+     */
+    FARMER(VillagerProfession.FARMER, 1),
+
+    /**
+     * Fisherman
+     */
+    FISHERMAN(VillagerProfession.FARMER, 2),
+
+    /**
+     * Shepherd
+     */
+    SHEPHERD(VillagerProfession.FARMER, 3),
+
+    /**
+     * Librarian
+     */
+    LIBRARIAN(VillagerProfession.LIBRARAIAN, 0),
+
+    /**
+     * Cleric
+     */
+    CLERIC(VillagerProfession.PRIEST, 0),
+
+    /**
+     * Tool smith
+     */
+    TOOL_SMITH(VillagerProfession.BLACKSMITH, 0),
+
+    /**
+     * Armorer
+     */
+    ARMORER(VillagerProfession.BLACKSMITH, 1),
+
+    /**
+     * Weapon smith
+     */
+    WEAPON_SMITH(VillagerProfession.BLACKSMITH, 2),
+
+    /**
+     * Butcher
+     */
+    BUTCHER(VillagerProfession.BUTCHER, 0),
+
+    /**
+     * Leatherworker
+     */
+    LEATHERWORKER(VillagerProfession.BUTCHER, 1);
+    private VillagerProfession parent;
+    private int id;
+
+    VillagerCareer(VillagerProfession parent, int id) {
+        this.parent = parent;
+        this.id = id;
+    }
+
+    private static Map<VillagerProfession, Collection<VillagerCareer>> byProfession = Maps.newHashMap();
+
+    static {
+        Collection<VillagerCareer> parentColl = Lists.newArrayList();
+        VillagerProfession current = null;
+        for (VillagerCareer carrer : VillagerCareer.values()) {
+            if (current == null) {
+                current = carrer.parent;
+                parentColl.add(carrer);
+                continue;
+            }
+            if (current == carrer.parent) {
+                parentColl.add(carrer);
+            } else {
+                byProfession.put(current, parentColl);
+                parentColl = Lists.newArrayList();
+                current = carrer.parent;
+            }
+        }
+    }
 
 }

--- a/src/main/java/net/tridentsdk/api/entity/VillagerProfession.java
+++ b/src/main/java/net/tridentsdk/api/entity/VillagerProfession.java
@@ -1,43 +1,72 @@
+/*
+ * Copyright (c) 2014, The TridentSDK Team
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ *     3. Neither the name of TridentSDK nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 package net.tridentsdk.api.entity;
 
 public enum VillagerProfession {
-	/**
-	 * Farmer
-	 */
-	FARMER(0),
-	
-	/**
-	 * Librarian
-	 */
-	LIBRARAIAN(1),
-	
-	/**
-	 * Priest
-	 */
-	PRIEST(2),
-	
-	/**
-	 * Blacksmith
-	 */
-	BLACKSMITH(3),
-	
-	/**
-	 * Butcher
-	 */
-	BUTCHER(4)
-	;
-	private int id;
-	
-	VillagerProfession(int id){
-		this.id = id;
-	}
-	
-	private static VillagerProfession[] byId = new VillagerProfession[5];
-	
-	static{
-		for(VillagerProfession profession : VillagerProfession.values()){
-			byId[profession.id] = profession;
-		}
-	}
+    /**
+     * Farmer
+     */
+    FARMER(0),
+
+    /**
+     * Librarian
+     */
+    LIBRARAIAN(1),
+
+    /**
+     * Priest
+     */
+    PRIEST(2),
+
+    /**
+     * Blacksmith
+     */
+    BLACKSMITH(3),
+
+    /**
+     * Butcher
+     */
+    BUTCHER(4);
+    private int id;
+
+    VillagerProfession(int id) {
+        this.id = id;
+    }
+
+    private static VillagerProfession[] byId = new VillagerProfession[5];
+
+    static {
+        for (VillagerProfession profession : VillagerProfession.values()) {
+            byId[profession.id] = profession;
+        }
+    }
 
 }

--- a/src/main/java/net/tridentsdk/api/entity/Wither.java
+++ b/src/main/java/net/tridentsdk/api/entity/Wither.java
@@ -1,10 +1,40 @@
+/*
+ * Copyright (c) 2014, The TridentSDK Team
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ *     3. Neither the name of TridentSDK nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 package net.tridentsdk.api.entity;
 
 /**
  * Represents a wither
- * 
- * @author TigerReborn
+ *
+ * @author TridentSDK Team
  */
 public interface Wither extends Hostile {
-    
+
 }

--- a/src/main/java/net/tridentsdk/api/entity/WitherSkull.java
+++ b/src/main/java/net/tridentsdk/api/entity/WitherSkull.java
@@ -1,9 +1,39 @@
+/*
+ * Copyright (c) 2014, The TridentSDK Team
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ *     3. Neither the name of TridentSDK nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 package net.tridentsdk.api.entity;
 
 /**
  * Represents a WitherSkull
- * 
- * @author TigerReborn
+ *
+ * @author TridentSDK Team
  */
 public interface WitherSkull extends Projectile {
 

--- a/src/main/java/net/tridentsdk/api/entity/Wolf.java
+++ b/src/main/java/net/tridentsdk/api/entity/Wolf.java
@@ -1,22 +1,52 @@
+/*
+ * Copyright (c) 2014, The TridentSDK Team
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ *     3. Neither the name of TridentSDK nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 package net.tridentsdk.api.entity;
 
 /**
  * Represents a Wolf
- * 
- * @author TigerReborn
+ *
+ * @author TridentSDK Team
  */
-public interface Wolf extends Tameable, Neutral{
-    
+public interface Wolf extends Tameable, Neutral {
+
     /**
      * Whether or not this entity is angry
-     * 
+     *
      * @return whether or not this entity is angry
      */
     boolean isAngry();
-    
+
     /**
      * The color of this entity's collar
-     * 
+     *
      * @return the color of this entity's collar
      */
     Object getCollarColor();    /* TODO: Decide valid implementation for this along with Sheep and Wool  */

--- a/src/main/java/net/tridentsdk/api/entity/Zombie.java
+++ b/src/main/java/net/tridentsdk/api/entity/Zombie.java
@@ -1,22 +1,52 @@
+/*
+ * Copyright (c) 2014, The TridentSDK Team
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ *     3. Neither the name of TridentSDK nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 package net.tridentsdk.api.entity;
 
 /**
  * Represents a Zombie
- * 
- * @author TigerReborn
+ *
+ * @author TridentSDK Team
  */
 public interface Zombie extends Hostile, Equippable {
-    
+
     /**
      * Represents if this zombie is a Zombie Villager or not
-     * 
+     *
      * @return whether or not this is a zombie villager
      */
     boolean isVillager();
-    
+
     /**
      * Represents if this zombie is a baby zombie or not
-     * 
+     *
      * @return whether or not this zombie is a baby zombie
      */
     boolean isBaby();

--- a/src/main/java/net/tridentsdk/api/inventory/FireworkProperties.java
+++ b/src/main/java/net/tridentsdk/api/inventory/FireworkProperties.java
@@ -1,10 +1,40 @@
+/*
+ * Copyright (c) 2014, The TridentSDK Team
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ *     3. Neither the name of TridentSDK nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 package net.tridentsdk.api.inventory;
 
 /**
  * Represents the various properties of a Firework ItemStack
  * Mock class only to show uses
- * 
- * @author TigerReborn
+ *
+ * @author TridentSDK Team
  */
 public interface FireworkProperties {
 

--- a/src/main/java/net/tridentsdk/api/inventory/Inventory.java
+++ b/src/main/java/net/tridentsdk/api/inventory/Inventory.java
@@ -1,6 +1,37 @@
+/*
+ * Copyright (c) 2014, The TridentSDK Team
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ *     3. Neither the name of TridentSDK nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 package net.tridentsdk.api.inventory;
 
 /**
  * Mock Inventory to provide reference to its uses until valid Inventory is implemented
  */
-public interface Inventory {}
+public interface Inventory {
+}

--- a/src/main/java/net/tridentsdk/api/inventory/ItemStack.java
+++ b/src/main/java/net/tridentsdk/api/inventory/ItemStack.java
@@ -1,6 +1,37 @@
+/*
+ * Copyright (c) 2014, The TridentSDK Team
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ *     3. Neither the name of TridentSDK nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 package net.tridentsdk.api.inventory;
 
 /**
  * Mock ItemStack for purposes to dictate its uses until a valid ItemStack is implemented
  */
-public class ItemStack {}
+public class ItemStack {
+}

--- a/src/main/java/net/tridentsdk/api/nbt/CompoundTag.java
+++ b/src/main/java/net/tridentsdk/api/nbt/CompoundTag.java
@@ -54,7 +54,8 @@ public class CompoundTag extends NBTTag implements TagContainer {
         return this.tags.containsKey(name) ? this.tags.get(name) : new NullTag(name);
     }
 
-    @Override public void addTag(NBTTag tag) {
+    @Override
+    public void addTag(NBTTag tag) {
         this.tags.put(tag.getName(), tag);
     }
 

--- a/src/main/java/net/tridentsdk/api/nbt/ListTag.java
+++ b/src/main/java/net/tridentsdk/api/nbt/ListTag.java
@@ -29,7 +29,9 @@ package net.tridentsdk.api.nbt;
 
 import com.google.common.collect.Lists;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 
 /**
  * @author The TridentSDK Team
@@ -55,7 +57,8 @@ public class ListTag extends NBTTag implements TagContainer {
         return this.tags.contains(tag);
     }
 
-    @Override public void addTag(NBTTag tag) {
+    @Override
+    public void addTag(NBTTag tag) {
         if (tag.getType() == innerType) {
             this.tags.add(tag);
         }

--- a/src/main/java/net/tridentsdk/api/trade/ItemPair.java
+++ b/src/main/java/net/tridentsdk/api/trade/ItemPair.java
@@ -1,43 +1,73 @@
+/*
+ * Copyright (c) 2014, The TridentSDK Team
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ *     3. Neither the name of TridentSDK nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 package net.tridentsdk.api.trade;
 
 import net.tridentsdk.api.inventory.ItemStack;
 
 /**
  * Represents a pair of ItemStacks designated in a trade
- * 
- * @author TigerReborn
+ *
+ * @author TridentSDK Team
  */
 public class ItemPair {
-	
-	private final ItemStack one, two;
-	
-	/**
-	 * Construct a ItemPair with only one input ItemStack
-	 * The second ItemStack will be considered null and thus will be treated as a single input when trading
-	 * 
-	 * @param one
-	 */
-	public ItemPair(ItemStack one){
-		this(one, null);
-	}
-	
-	/**
-	 * Construct a ItemPair with two input ItemStacks
-	 * When used in a trade, the pair will be treated as a double input when trading
-	 * 
-	 * @param one
-	 */
-	public ItemPair(ItemStack one, ItemStack two){
-		this.one = one;
-		this.two = two;
-	}
-	
-	public ItemStack getFirstInput(){
-		return one;
-	}
-	
-	public ItemStack getSecondInput(){
-		return two;
-	}
-	
+
+    private final ItemStack one, two;
+
+    /**
+     * Construct a ItemPair with only one input ItemStack
+     * The second ItemStack will be considered null and thus will be treated as a single input when trading
+     *
+     * @param one
+     */
+    public ItemPair(ItemStack one) {
+        this(one, null);
+    }
+
+    /**
+     * Construct a ItemPair with two input ItemStacks
+     * When used in a trade, the pair will be treated as a double input when trading
+     *
+     * @param one
+     */
+    public ItemPair(ItemStack one, ItemStack two) {
+        this.one = one;
+        this.two = two;
+    }
+
+    public ItemStack getFirstInput() {
+        return one;
+    }
+
+    public ItemStack getSecondInput() {
+        return two;
+    }
+
 }

--- a/src/main/java/net/tridentsdk/api/trade/Trade.java
+++ b/src/main/java/net/tridentsdk/api/trade/Trade.java
@@ -1,48 +1,78 @@
+/*
+ * Copyright (c) 2014, The TridentSDK Team
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ *     3. Neither the name of TridentSDK nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 package net.tridentsdk.api.trade;
 
 import net.tridentsdk.api.inventory.ItemStack;
 
 /**
  * Represents a Trade offered by an {@link net.tridentsdk.api.entity.Tradeable}
- * 
- * @author TigerReborn
+ *
+ * @author TridentSDK Team
  */
 public interface Trade {
 
-	/**
-	 * Whether or not this trade rewards xp
-	 * 
-	 * @return Whether or not this trade should reward xp
-	 */
-	boolean rewardExp();
-	
-	/**
-	 * How many times this trade can be fulfilled
-	 * 
-	 * @return the number of times this trade can be fulfilled
-	 */
-	int maxUses();
-	
-	/**
-	 * How many times this trade has been fulfilled
-	 * 
-	 * @return how many times this trade has been fulfilled
-	 */
-	int uses();
-	
-	/**
-	 * The itemstack given as a result of this trade
-	 * 
-	 * @return the itemstack that is given as a result of fulfilling this trade
-	 */
-	ItemStack offer();
-	
-	/**
-	 * The itemstacks required to be input in order to fulfilled this trade
-	 * This accepts both implementations of ItemPair, including a null second offer
-	 * 
-	 * @return the input that will fulfill this trade
-	 */
-	ItemPair input();
-	
+    /**
+     * Whether or not this trade rewards xp
+     *
+     * @return Whether or not this trade should reward xp
+     */
+    boolean rewardExp();
+
+    /**
+     * How many times this trade can be fulfilled
+     *
+     * @return the number of times this trade can be fulfilled
+     */
+    int maxUses();
+
+    /**
+     * How many times this trade has been fulfilled
+     *
+     * @return how many times this trade has been fulfilled
+     */
+    int uses();
+
+    /**
+     * The itemstack given as a result of this trade
+     *
+     * @return the itemstack that is given as a result of fulfilling this trade
+     */
+    ItemStack offer();
+
+    /**
+     * The itemstacks required to be input in order to fulfilled this trade
+     * This accepts both implementations of ItemPair, including a null second offer
+     *
+     * @return the input that will fulfill this trade
+     */
+    ItemPair input();
+
 }

--- a/src/main/java/net/tridentsdk/api/util/PartRotation.java
+++ b/src/main/java/net/tridentsdk/api/util/PartRotation.java
@@ -1,20 +1,50 @@
+/*
+ * Copyright (c) 2014, The TridentSDK Team
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ *     3. Neither the name of TridentSDK nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 package net.tridentsdk.api.util;
 
 /**
  * Represents the rotation of an Armor Stand part
- * 
- * @author TigerReborn
+ *
+ * @author TridentSDK Team
  */
 public class PartRotation {
-    
+
     private int rotX, rotY, rotZ;
-    
-    public PartRotation(int rotX, int rotY, int rotZ){
+
+    public PartRotation(int rotX, int rotY, int rotZ) {
         this.rotX = rotX;
         this.rotY = rotY;
         this.rotZ = rotZ;
     }
-   
+
     public int getRotX() {
         return rotX;
     }

--- a/src/main/java/net/tridentsdk/plugin/PluginClassLoader.java
+++ b/src/main/java/net/tridentsdk/plugin/PluginClassLoader.java
@@ -28,7 +28,9 @@
 package net.tridentsdk.plugin;
 
 import java.io.File;
-import java.net.*;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLClassLoader;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -37,7 +39,7 @@ public class PluginClassLoader extends URLClassLoader {
     private Class<? extends TridentPlugin> pluginClass;
 
     PluginClassLoader(File pluginFile) throws MalformedURLException {
-        super(new URL[] { pluginFile.toURI().toURL() });
+        super(new URL[]{pluginFile.toURI().toURL()});
     }
 
     @Override

--- a/src/main/java/net/tridentsdk/plugin/TridentPlugin.java
+++ b/src/main/java/net/tridentsdk/plugin/TridentPlugin.java
@@ -36,7 +36,8 @@ public class TridentPlugin {
     private File pluginFile;
     private PluginDescription description;
 
-    protected TridentPlugin() {} // avoid any plugin initiation outside of this package
+    protected TridentPlugin() {
+    } // avoid any plugin initiation outside of this package
 
     TridentPlugin(File pluginFile, PluginDescription description) {
         this.pluginFile = pluginFile;

--- a/src/main/java/net/tridentsdk/plugin/TridentPluginLoader.java
+++ b/src/main/java/net/tridentsdk/plugin/TridentPluginLoader.java
@@ -33,7 +33,10 @@ import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.List;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 

--- a/src/main/java/net/tridentsdk/plugin/annotation/PluginDescription.java
+++ b/src/main/java/net/tridentsdk/plugin/annotation/PluginDescription.java
@@ -27,7 +27,10 @@
 
 package net.tridentsdk.plugin.annotation;
 
-import java.lang.annotation.*;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
@@ -43,7 +46,7 @@ public @interface PluginDescription {
 
     String author() default "";
 
-    String[] authors() default { };
+    String[] authors() default {};
 
-    String[] dependencies() default { };
+    String[] dependencies() default {};
 }


### PR DESCRIPTION
Introduces a generalized format for Entity implementation. Currently in Trident, there is a small amount of design towards Entities, therefor I decided to PR a generalized design that can be modified and edited by the Trident team. 
**An edit to this: All code was based off of http://minecraft.gamepedia.com/Chunk_format#Entity_Format and my opinions on how things could be done.

The design is as follows:

Details:
- Base interfaces for Entities
- Enum representation of various "types" for Entities
- Various "Property" classes to represent where an Entity will have extra properties that can vary
- Mock Classes used to show usages and not actual implementation

This also introduces some other potential API occurrences:
- Villager Trading API
- Spawner API (through the use of the EntityProperties)
- Minecart Tile API

All of these were not present in previously used APIs in Minecraft and would be a useful API that would be planned out in the future

There are things that are marked as "TODO" due to the fact that there is still a lack of some API involving BlockStates and other things such as Dye Coloring, they are as followed:
- BlockState todos
- DyeColor todos
- Horse variant todos
- Anything not mentioned may be commented about and can be explained in detail

There are also many introduced concepts, nothing should be taken as "final", and the code can be subject to change at any time, this may include:
- "Property"-based interfaces
- ArmorStand-bases features (currently includes a deprecated api for parts)
- Any additional API that was introduced as a caused of this (Trade, Minecart, Spawner)

Note, the code is not Javadoc'd and commented as best as it can, thus may be required to be proofread by others and given input on such.

If you have a problem with something, just comment on the PR and I will comment on it
