### PR TITLE
Complete Materials API

### DIFF
--- a/src/main/java/net/tridentsdk/api/Material.java
+++ b/src/main/java/net/tridentsdk/api/Material.java
@@ -531,7 +531,7 @@ public enum Material {
      * 
      * @return True if the item is a disc (record)
      */
-    public boolean isDisc(){
+    public boolean isDisc() {
         if(!isBlock()){
             if(idInt >= 2256){
                 return true;


### PR DESCRIPTION
I added all blocks and items, the names are the same as the bukkit API.

Methods:
- getMaxStackSize, returns what the maximum size for a stack is.
- hasGravity, returns true if the block falls when placed or not.
- isBlock, returns true if the Material is a block and can be placed.
- isBurnable returns true if the block can get destroyed by fire.
- isDisc, returns true if the Item is a record/disc.
- isEdible, returns true if the is food.
- isFlammable, returns true if the block catches fire.
- isSolid, returns true when the block is solid.
- isWearable, returns true if the item is armor.

Reason: The materials API was incomplete.
