### PR TITLE
Blacklist certain plugin names, as well as minor checks of plugin name

### DIFF
--- a/src/main/java/net/tridentsdk/plugin/TridentPluginLoader.java
+++ b/src/main/java/net/tridentsdk/plugin/TridentPluginLoader.java
@@ -70,6 +70,17 @@ public class TridentPluginLoader {
                 throw new PluginLoadException("Description annotation does not exist!");
             }
 
+            if (description.name() == null) {
+                throw new PluginLoadException("Plugin has no name!");
+            }
+
+            if (description.name().equalsIgnoreCase("Trident")
+                    || description.name().equalsIgnoreCase("TridentSDK")
+                    || description.name().equalsIgnoreCase("Mojang")
+                    || description.name().equalsIgnoreCase("Microsoft")) {
+                throw new PluginLoadException("Plugin is using invalid name!");
+            }
+
             Constructor<? extends TridentPlugin> defaultConstructor =
                     pluginClass.getConstructor(File.class, PluginDescription.class);
             TridentPlugin plugin = defaultConstructor.newInstance(pluginFile, description);

--- a/src/main/java/net/tridentsdk/plugin/annotation/PluginDescription.java
+++ b/src/main/java/net/tridentsdk/plugin/annotation/PluginDescription.java
@@ -43,9 +43,7 @@ public @interface PluginDescription {
 
     String description() default "Plugin made for TridentSDK";
 
-    String author() default "";
+    String[] authors();
 
-    String[] authors() default {};
-
-    String[] dependencies() default {};
+    String[] dependencies();
 }


### PR DESCRIPTION
As explained by title.

This PR could be considered controversial, however I feel it is the right move to protect this project as well as encourage proper names.

It also merges `String author` into `String[] author` - Having both variables could be considered confusing/unnecessary.
