### PR TITLE
Fix spelling error in World.getDifficulty()

### DIFF
--- a/src/main/java/net/tridentsdk/api/world/World.java
+++ b/src/main/java/net/tridentsdk/api/world/World.java
@@ -46,7 +46,7 @@ public interface World {
 
     Dimension getDimesion();
 
-    Difficulty getDifficulity();
+    Difficulty getDifficulty();
 
     GameMode getDefaultGamemode();
 


### PR DESCRIPTION
It used to be World.getDifficulity() and should be World.getDifficulty() instead.
